### PR TITLE
fix AttributeError for palette in LaunchpadPro class

### DIFF
--- a/launchpad.py
+++ b/launchpad.py
@@ -105,7 +105,7 @@ class LaunchpadPro(LaunchPad):
         # This SysEx message switches the LaunchPad Pro to "programmer" mode
         mido.Message("sysex", data=[0, 32, 41, 2, 16, 44, 3]),
         # And this one sets the front/side LED
-        mido.Message("sysex", data=[0, 32, 41, 2, 16, 10, 99, palette.BLACK]),
+        mido.Message("sysex", data=[0, 32, 41, 2, 16, 10, 99, 0]),
     ]
 
 


### PR DESCRIPTION
In launchpad.py, `palette` is being imported at the top and also declared as a string in the `LaunchpadPro` class, causing confusion.  A quick resolution is to replace `palette.BLACK` with its actual value of 0 for now. 